### PR TITLE
Fix incomplete Quagga configuration for spine02

### DIFF
--- a/mlag/spine02/Quagga.conf
+++ b/mlag/spine02/Quagga.conf
@@ -1,6 +1,6 @@
 !
-router bgp 65020
- bgp router-id 10.0.0.21
+router bgp 65021
+ bgp router-id 10.0.0.22
  bgp bestpath as-path multipath-relax
  neighbor fabric peer-group
  neighbor fabric remote-as external
@@ -12,7 +12,7 @@ router bgp 65020
  neighbor swp4 interface peer-group fabric
  !
  address-family ipv4 unicast
-  network 10.0.0.21/32
+  network 10.0.0.22/32
   neighbor fabric prefix-list dc-spine in
   neighbor fabric prefix-list dc-spine out
  exit-address-family
@@ -22,4 +22,10 @@ router bgp 65020
   neighbor fabric activate
  exit-address-family
  exit
+!
+ip prefix-list dc-spine seq 10 permit 0.0.0.0/0
+ip prefix-list dc-spine seq 20 permit 10.0.0.0/24 le 32
+ip prefix-list dc-spine seq 30 permit 172.16.1.0/24
+ip prefix-list dc-spine seq 40 permit 172.16.2.0/24
+ip prefix-list dc-spine seq 500 deny any
 !


### PR DESCRIPTION
Not the right loopback address. Prefix-lists were missing and the AS
number was shared with spine01.